### PR TITLE
Update to latest major wordpress and woocommerce version

### DIFF
--- a/includes/class-wcqu-actions.php
+++ b/includes/class-wcqu-actions.php
@@ -1,89 +1,89 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units_Actions' ) ) :
 
 class WC_Quantities_and_Units_Actions {
-		
+
 	public function __construct() {
-		
+
 		// Conditionally add quantity note to product page
 		$settings = get_option( 'ipq_options' );
 
 		if ( isset( $settings['ipq_show_qty_note'] ) and $settings['ipq_show_qty_note'] == 'on' ) {
 			add_action( 'init', array( $this, 'apply_product_notification' ) );
 		}
-		
+
 		// Add quantity message shortcode
 		add_shortcode('wpbo_quantity_message', array( $this, 'display_minimum_quantity_note' ));
-		
+
 	}
 
 	/*
-	*	Adds minimum product notification at correct action level 
+	*	Adds minimum product notification at correct action level
 	*	if users applies message
 	*
-	*	@access public 
+	*	@access public
 	*	@return void
-	*/								
+	*/
 	public function apply_product_notification() {
 
 		$settings = get_option( 'ipq_options' );
 		extract( $settings );
-		
+
 		if ( isset( $ipq_show_qty_note ) and $ipq_show_qty_note == 'on' ) {
-			
+
 			// Get add_to_cart action priority
 			global $wp_filter;
 			$action_to_check = 'woocommerce_single_product_summary';
 			$target_function = 'woocommerce_template_single_add_to_cart';
 			$cart_priority = has_filter( $action_to_check, $target_function );
-			
+
 			// Set the priory level based on add to cart
 			if ( $cart_priority == null ) {
 				$priority = 30;
-				
+
 			} elseif ( isset( $ipq_show_qty_note_pos ) and $ipq_show_qty_note_pos == 'below' ) {
 				$priority = $cart_priority + 1;
-												
+
 			} else {
 				$priority = $cart_priority - 1;
 			}
-			
+
 			add_action( 'woocommerce_single_product_summary', array( $this, 'display_minimum_quantity_note' ), $priority );
-			
-		}	
+
+		}
 	}
-	
+
 	/*
 	*	Print the minimum quantity note based on user specs
 	*
-	*	@access public 
+	*	@access public
 	*	@return void
-	*/	
+	*/
 	public function display_minimum_quantity_note() {
-	
+
 		global $product;
-		
+
 		if ( !is_product() ) {
 			return;
 		}
-		
-		if( $product->product_type == 'grouped' )
+
+		if( $product->get_type() == 'grouped' )
 			return;
-		
+
 		$settings = get_option( 'ipq_options' );
 		extract( $settings );
-		
-		// Get minimum value for product 
+
+		// Get minimum value for product
 		$rule = wcqu_get_applied_rule( $product );
-		
+
 		// Return nothing if APQ is deactivated
 		if ( $rule == 'inactive' or $rule == null ) {
-			return; 
+			return;
 		}
-		
-		// Check if the product is out of stock 
+
+		// Check if the product is out of stock
 		$stock = $product->get_stock_quantity();
 
 		// Check if the product is under stock management and out of stock
@@ -93,7 +93,7 @@ class WC_Quantities_and_Units_Actions {
 		} else {
 			$min = wcqu_get_value_from_rule( 'min', $product, $rule );
 			$max = wcqu_get_value_from_rule( 'max', $product, $rule );
-		}	
+		}
 
 		$step = wcqu_get_value_from_rule( 'step', $product, $rule );
 
@@ -101,25 +101,25 @@ class WC_Quantities_and_Units_Actions {
 		if ( $rule == 'sitewide' and strlen( $stock ) != 0 and $stock <= 0  ) {
 			if ( is_array( $min ) )
 				$min = $min['min_oos'];
-		
+
 			if ( is_array( $max ) )
 				$max = $max['max_oos'];
-				
+
 			if ( is_array( $step ) ) {
 				$step = $step['step'];
 			}
 		} else if ( $rule == 'sitewide' ) {
 			if ( is_array( $min ) )
 				$min = $min['min'];
-		
+
 			if ( is_array( $max ) )
 				$max = $max['max'];
-				
+
 			if ( is_array( $step ) ) {
 				$step = $step['step'];
 			}
 		}
-		
+
 		// If the text is set, update and print the output
 		if ( isset( $ipq_qty_text ) ) {
 			$min_pattern = '/\%MIN\%/';
@@ -134,7 +134,7 @@ class WC_Quantities_and_Units_Actions {
 			echo "<span";
 			if ( isset( $ipq_qty_class ) and $ipq_qty_class != '' )
 				echo " class='" . $ipq_qty_class . "'";
-			echo ">";	
+			echo ">";
 			echo $ipq_qty_text;
 			echo "</span>";
 		}

--- a/includes/class-wcqu-filters.php
+++ b/includes/class-wcqu-filters.php
@@ -1,17 +1,17 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units_Filters' ) ) :
 
 class WC_Quantities_and_Units_Filters {
-		
+
 	public function __construct() {
-		
+
 		// Cart input box variable filters
 		add_filter( 'woocommerce_quantity_input_min', array( $this, 'input_min_value' ), 10, 2);
 		add_filter( 'woocommerce_quantity_input_max', array( $this, 'input_max_value' ), 10, 2);
 		add_filter( 'woocommerce_quantity_input_step', array( $this, 'input_step_value' ), 10, 2);
-		
+
 		// Product input box argument filter
 		add_filter( 'woocommerce_quantity_input_args', array( $this, 'input_set_all_values' ), 10, 2 );
 
@@ -19,19 +19,19 @@ class WC_Quantities_and_Units_Filters {
 	}
 
 	/**
-	 * This method ensures that if a minimum has been set, that we 
+	 * This method ensures that if a minimum has been set, that we
 	 * specify that when the ajax add to cart function is enabled.
 	 * Also if a step is set, but no minimum, we'll use that.
 	 * Only works with WooCommerce 2.5+
-	 * 
+	 *
 	 * @param array $args
 	 * @param WC_Product $product
 	 *
 	 * @return mixed
 	 */
 	public function woocommerce_loop_add_to_cart_args( $args, $product ) {
-		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		// Return Defaults if it isn't a simple product
+		if( $product->get_type() != 'simple' ) {
 			return $args;
 		}
 
@@ -41,43 +41,43 @@ class WC_Quantities_and_Units_Filters {
 		// Get Value from Rule
 		$min = wcqu_get_value_from_rule( 'min', $product, $rule );
 		$min = isset($min['min']) ? $min['min'] : 1;
-		
+
 		$step = wcqu_get_value_from_rule( 'step', $product, $rule );
 		$step = isset($step['step']) ? $step['step'] : 1;
-		
+
 		if(!$min && $step > 0){
 			$args['quantity'] = $step;
-		} 
+		}
 		else if($min > 0){
 			$args['quantity'] = $min;
 		}
-			
-		
+
+
 		return $args;
 	}
 
 	/*
 	*	Filter Minimum Quantity Value for Input Boxes for Cart
 	*
-	*	@access public 
+	*	@access public
 	*	@param  int 	default
 	*	@param  obj		product
 	*	@return int		step
 	*
-	*/								
+	*/
 	public function input_min_value( $default, $product ) {
 
-		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		// Return Defaults if it isn't a simple product
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
-		
+
 		// Get Rule
 		$rule = wcqu_get_applied_rule( $product );
 
 		// Get Value from Rule
 		$min = wcqu_get_value_from_rule( 'min', $product, $rule );
-		
+
 		// Return Value
 		if ( $min == '' or $min == null or (isset($min['min']) and $min['min'] == "")) {
 			return $default;
@@ -85,29 +85,29 @@ class WC_Quantities_and_Units_Filters {
 			return $min;
 		}
 	}
-	
+
 	/*
 	*	Filter Maximum Quantity Value for Input Boxes for Cart
 	*
-	*	@access public 
+	*	@access public
 	*	@param  int 	default
 	*	@param  obj		product
 	*	@return int		step
 	*
-	*/	
-	public function input_max_value( $default, $product ) {	
-		
+	*/
+	public function input_max_value( $default, $product ) {
+
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
-		
+
 		// Get Rule
 		$rule = wcqu_get_applied_rule( $product );
-		
+
 		// Get Value from Rule
 		$max = wcqu_get_value_from_rule( 'max', $product, $rule );
-	
+
 		// Return Value
 		if ( $max == '' or $max == null or (isset($max['max']) and $max['max'] == "")) {
 			return $default;
@@ -115,52 +115,52 @@ class WC_Quantities_and_Units_Filters {
 			return $max;
 		}
 	}
-	
+
 	/*
 	*	Filter Step Quantity Value for Input Boxes woocommerce_quantity_input_step for Cart
 	*
-	*	@access public 
+	*	@access public
 	*	@param  int 	default
 	*	@param  obj		product
 	*	@return int		step
 	*
-	*/	
+	*/
 	public function input_step_value( $default, $product ) {
-		
+
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $default;
 		}
-		
+
 		// Get Rule
 		$rule = wcqu_get_applied_rule( $product );
-		
+
 		// Get Value from Rule
 		$step = wcqu_get_value_from_rule( 'step', $product, $rule );
-	
+
 		// Return Value
 		if ( $step == '' or $step == null or (isset($step['step']) and $step['step'] == "")) {
 			return $default;
 		} else {
 			return isset($step['step']) ? $step['step'] : $step;
 		}
-	}	
-	
+	}
+
 	/*
 	*	Filter Step, Min and Max for Quantity Input Boxes on product pages
 	*
-	*	@access public 
+	*	@access public
 	*	@param  array 	args
 	*	@param  obj		product
 	*	@return array	vals
 	*
-	*/	
+	*/
 	public function input_set_all_values( $args, $product ) {
-		
+
 		// Return Defaults if it isn't a simple product
 		/* Commented out to allow for grouped and variable products
 		*  on their product pages
-		if( $product->product_type != 'simple' ) {
+		if( $product->get_type() != 'simple' ) {
 			return $args;
 		}
 		*/
@@ -174,40 +174,40 @@ class WC_Quantities_and_Units_Filters {
 		if ( $values == null ) {
 			return $args;
 		}
-		
+
 		$vals = array();
 		$vals['input_name'] = 'quantity';
-		
-		// Check if the product is out of stock 
+
+		// Check if the product is out of stock
 		$stock = $product->get_stock_quantity();
-		
-		// Check stock status and if Out try Out of Stock value	
+
+		// Check stock status and if Out try Out of Stock value
 		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $values['min_oos'] ) and $values['min_oos'] != '' ) {
 			$args['min_value'] = $values['min_oos'];
-			
-		// Otherwise just check normal min	
+
+		// Otherwise just check normal min
 		} elseif ( $values['min_value'] != ''  ) {
 			$args['min_value'] 	 = $values['min_value'];
-		
-		// If no min, try step	
+
+		// If no min, try step
 		} elseif ( $values['min_value'] == '' and $values['step'] != '' ) {
 			$args['min_value'] 	 = $values['step'];
-		} 
-		
-		// Check stock status and if Out try Out of Stock value	
+		}
+
+		// Check stock status and if Out try Out of Stock value
 		if ( $stock <= 0 and isset( $values['min_oos'] ) and $values['max_oos'] != '' ) {
 			$args['max_value'] = $values['max_oos'];
-		
-		// Otherwise just check normal max	
+
+		// Otherwise just check normal max
 		} elseif ($values['max_value'] != ''  ) {
 			$args['max_value'] 	 = $values['max_value'];
 		}
-		
+
 		// Set step value
 		if ( $values['step'] != '' ) {
 			$args['step'] = $values['step'];
 		}
-		
+
 		return $args;
 	}
 

--- a/includes/class-wcqu-post-type.php
+++ b/includes/class-wcqu-post-type.php
@@ -1,20 +1,20 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units_Quantity_Rule_Post_Type' ) ) :
 
 class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
-	
+
 	public function __construct() {
-		
+
 		// Add the quantity-rule post type
 		add_action( 'init', array( $this, 'quantity_rule_init' ) );
-		
+
 		// Adjust post type columns on list view
 		add_action( 'manage_edit-quantity-rule_columns', array( $this, 'quantity_rule_columns' ), 10, 2 );
 		add_action( 'manage_quantity-rule_posts_custom_column', array( $this, 'manage_quantity_rule_columns' ), 10, 2);
-		add_filter( 'manage_edit-quantity-rule_sortable_columns', array( $this, 'sortable_quantity_rule_columns' ) ); 
-		
+		add_filter( 'manage_edit-quantity-rule_sortable_columns', array( $this, 'sortable_quantity_rule_columns' ) );
+
 		// Add custom meta boxes
 		add_action( 'add_meta_boxes', array( $this, 'quantity_rule_meta_init' 	) );
 		add_action( 'add_meta_boxes', array( $this, 'quantity_rule_tax_init' 	) );
@@ -23,19 +23,19 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		add_action( 'add_meta_boxes', array( $this, 'rate_us_notice' 			) );
 //		add_action( 'add_meta_boxes', array( $this, 'input_thumbnail_notice' 	) );
 		add_action( 'add_meta_boxes', array( $this, 'company_notice' 			) );
-		
+
 		// Save post meta on post update
 		add_action( 'save_post', array( $this, 'save_quantity_rule_meta'  ) );
 		add_action( 'save_post', array( $this, 'save_quantity_rule_taxes' ) );
 		add_action( 'save_post', array( $this, 'save_quantity_rule_tags'  ) );
 		add_action( 'save_post', array( $this, 'save_quantity_rule_roles' ) );
 	}
-	
+
 	/*
 	*	Register Quantity Rule Post Type
-	*/	
+	*/
 	public function quantity_rule_init() {
-	
+
 		$labels = array(
 			'name'               => 'Quantity Rules',
 			'singular_name'      => 'Quantity Rule',
@@ -51,7 +51,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			'parent_item_colon'  => '',
 			'menu_name'          => 'Quantity Rules'
 		);
-		
+
 		$args = array(
 			'labels'             => $labels,
 			'public'             => false,
@@ -67,21 +67,21 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			'supports'           => array( 'title' ),
 			'taxonomies' 		 => array(),
 		);
-		
+
 		register_post_type( 'quantity-rule', $args );
 	}
-	
+
 	/*
 	*	Register Custom Columns for List View
-	*/	
+	*/
 	public function quantity_rule_columns( $column ) {
-	 	
+
 	 	unset( $column['date'] );
-	 	
+
 	    $new_columns['priority'] = __('Priority');
 	    $new_columns['min'] = __('Minimum');
 	    $new_columns['max'] = __('Maximum');
-	    $new_columns['step'] = __('Step Value');     
+	    $new_columns['step'] = __('Step Value');
 	    $new_columns['cats'] = __('Categories');
 	    $new_columns['product_tags'] = __('Tags');
 	    $new_columns['roles'] = __('Roles');
@@ -89,174 +89,174 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 
 	    return array_merge( $column, $new_columns );
 	}
-	
+
 	/*
 	*	Get Custom Columns Values for List View
-	*/	 
+	*/
 	public function manage_quantity_rule_columns($column_name, $id) {
-	    
+
 	    switch ($column_name) {
-	    
+
 		    case 'priority':
 		        echo get_post_meta( $id, '_priority', true );
 		        break;
-		 
+
 		    case 'min':
 	   	        echo get_post_meta( $id, '_min', true );
 		        break;
-		        
+
 		    case 'max':
 	   	        echo get_post_meta( $id, '_max', true );
 		        break;
-		        
+
 		    case 'step':
-		        echo get_post_meta( $id, '_step', true );	       
+		        echo get_post_meta( $id, '_step', true );
 		        break;
-		        
+
 		    case 'cats':
 		   		$cats = get_post_meta( $id, '_cats', false);
-		   		if ( $cats != false and count( $cats[0] ) > 0 ) {	   		
+		   		if ( $cats != false and count( $cats[0] ) > 0 ) {
 			   		foreach ( $cats[0] as $cat ){
-		
-			   			$taxonomy = 'product_cat'; 	
+
+			   			$taxonomy = 'product_cat';
 				   		$term = get_term_by( 'id', $cat, $taxonomy );
-			   			$link = get_term_link( $term );	
-			   			
-			   			echo "<a href='" . $link . "'>" . $term->name . "</a><br />";	
+			   			$link = get_term_link( $term );
+
+			   			echo "<a href='" . $link . "'>" . $term->name . "</a><br />";
 			   		}
-			   	} 
-		        break;  
-		        
+			   	}
+		        break;
+
 		    case 'product_tags':
 		    	$tags = get_post_meta( $id, '_tags', false);
-		   		if ( $tags != null and count( $tags[0] ) > 0) {	   		
+		   		if ( $tags != null and count( $tags[0] ) > 0) {
 			   		foreach ( $tags[0] as $tag ){
-		
-			   			$taxonomy = 'product_tag'; 	
+
+			   			$taxonomy = 'product_tag';
 				   		$term = get_term_by( 'id', $tag, $taxonomy );
-			   			$link = get_term_link( $term );	
-			   			
-			   			echo "<a href='" . $link . "'>" . $term->name . "</a><br />";	
+			   			$link = get_term_link( $term );
+
+			   			echo "<a href='" . $link . "'>" . $term->name . "</a><br />";
 			   		}
-			   	} 
+			   	}
 		    	break;
-		    
+
 		    case 'roles':
 		   		$roles = get_post_meta( $id, '_roles', false);
-		   		if ( $roles != null and count( $roles[0] ) > 0) {	   		
+		   		if ( $roles != null and count( $roles[0] ) > 0) {
 			   		foreach ( $roles[0] as $role ){
-			   			echo ucfirst( $role ) . "<br />";	
+			   			echo ucfirst( $role ) . "<br />";
 			   		}
-			   	} 
+			   	}
 		    	break;
-		    	
+
 		    default:
 		        break;
-	    } 
-	}   
-	
+	    }
+	}
+
 	/*
 	*	Make Custom Columns Sortable
-	*/	
-	public function sortable_quantity_rule_columns( $columns ) {  
-	    
+	*/
+	public function sortable_quantity_rule_columns( $columns ) {
+
 	    $columns['priority'] = __('Priority');
 	    $columns['min'] = __('Minimum');
 	    $columns['max'] = __('Maximum');
 	    $columns['step'] = __('Step Value');
-	  
-	    return $columns;  
-	}  
-	
+
+	    return $columns;
+	}
+
 	/*
 	*	Register and Create Rule Options Meta Box for Quantity Rules
-	*/	
+	*/
 	public function quantity_rule_meta_init() {
 		add_meta_box(
-			'wpbo-quantity-rule-meta', 
-			'Set Quantity Rule Options', 
-			array( $this, 'quantity_rule_meta' ), 
-			'quantity-rule', 
-			'normal', 
+			'wpbo-quantity-rule-meta',
+			'Set Quantity Rule Options',
+			array( $this, 'quantity_rule_meta' ),
+			'quantity-rule',
+			'normal',
 			'high'
 		);
 	}
-	
+
 	public function quantity_rule_meta( $post ) {
-		
+
 		$min  = get_post_meta( $post->ID, '_min', true);
 		$max  = get_post_meta( $post->ID, '_max', true);
 		$min_oos = get_post_meta( $post->ID, '_min_oos', true );
-		$max_oos = get_post_meta( $post->ID, '_max_oos', true );		
+		$max_oos = get_post_meta( $post->ID, '_max_oos', true );
 		$step = get_post_meta( $post->ID, '_step', true);
 		$priority = get_post_meta( $post->ID, '_priority', true);
-		
+
 		// Create Nonce Field
 		wp_nonce_field( plugin_basename( __FILE__ ), '_wpbo_rule_value_nonce' );
-		
+
 		?>
 			<div class="wpbo-meta">
 				<label for="min">Minimum</label>
 				<input type="number" name="min" id="min" value="<?php echo $min ?>" step="any" />
-			
+
 				<label for="max">Maximum</label>
 				<input type="number" name="max" id="max" value="<?php echo $max ?>" step="any" />
-				
+
 				<label for="_wpbo_minimum_oos">Out of Stock Minimum</label>
 				<input type="number" name="min_oos" value="<?php echo $min_oos ?>" step="any" />
-				
+
 				<label for="_wpbo_maximum_oos">Out of Stock Maximum</label>
 				<input type="number" name="max_oos" value="<?php echo $max_oos ?>" step="any" />
-				
+
 				<label for="step">Step Value</label>
 				<input type="number" step="any" name="step" id="step" value="<?php echo $step ?>" step="any" />
-				
+
 				<label for="step">Priority</label>
-				<input type="number" name="priority" id="priority" value="<?php echo $priority ?>" />			
+				<input type="number" name="priority" id="priority" value="<?php echo $priority ?>" />
 			</div>
 			<p><em>*Note - the minimum value must be greater then or equal to the step value.</em><br />
 			<em>*Note - The rule with the lowest priority number will be used if multiple rules are applied to a single product.</em></p>
-		<?php	
+		<?php
 	}
-	
+
 	/*
 	*	Register and Create Product Category Meta Box for quantity Rule
-	*/	
+	*/
 	public function quantity_rule_tax_init() {
-		add_meta_box(	
-			'wpbo-quantity-rule-tax-meta', 
-			'Product Categories', 
-			array( $this, 'quantity_rule_tax_meta' ), 
-			'quantity-rule', 
-			'normal', 
+		add_meta_box(
+			'wpbo-quantity-rule-tax-meta',
+			'Product Categories',
+			array( $this, 'quantity_rule_tax_meta' ),
+			'quantity-rule',
+			'normal',
 			'high'
 		);
 	}
-	
+
 	function quantity_rule_tax_meta( $post ) {
-	
+
 		// Get selected categories
 		$cats = get_post_meta( $post->ID, '_cats', false);
-	
+
 		if ( $cats != null ) {
 			$cats = $cats[0];
 		}
-		
+
 		// Get all possible categories
 		$tax_name = 'product_cat';
-		
-		$args = array( 
+
+		$args = array(
 			'parent' => 0,
 			'hide_empty' => false
 			);
-		
+
 		$terms = get_terms( $tax_name, $args );
-		
+
 		if ( $terms ){
-			
+
 			// Create Nonce Field
 			wp_nonce_field( plugin_basename( __FILE__ ), '_wpbo_tax_nonce' );
-		
+
 			echo '<ul class="rule-product-cats level-1">';
 			foreach ( $terms as $term ) {
 				$this->print_tax_inputs( $term, $tax_name, $cats, 2 );
@@ -264,22 +264,22 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			echo '</ul>';
 		}
 	}
-		
+
 	/*
 	*	Will Recursivly Print all Product Categories with heirarcy included
 	*/
-	public function print_tax_inputs( $term, $taxonomy_name, $cats, $level ) { 
-		
+	public function print_tax_inputs( $term, $taxonomy_name, $cats, $level ) {
+
 		// Echo Single Item
 		?>
 			<li>
 				<input type="checkbox" id="_wpbo_cat_<?php echo $term->term_id ?>" name="_wpbo_cat_<?php echo $term->term_id ?>" <?php if ( is_array( $cats ) and in_array( $term->term_id, $cats )) echo 'checked="checked"' ?> /><?php echo $term->name; ?>
 			</li>
-		<?php 
-		
+		<?php
+
 		// Get any Children
 		$children = get_term_children( $term->term_id, $taxonomy_name );
-		
+
 		// Continue to print children if they exist
 		if ( $children ){
 			echo '<ul class="level-' . $level . '">';
@@ -294,33 +294,33 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			echo '</ul>';
 		}
 	}
-	
+
 	/*
 	*	Allow users to apply rules by tags
-	*/	
+	*/
 	public function quantity_rule_tag_init() {
-		add_meta_box(	
-			'wpbo-quantity-rule-tag-meta', 
-			'Product Tags', 
-			array( $this, 'quantity_rule_tag_meta' ), 
-			'quantity-rule', 
-			'normal', 
+		add_meta_box(
+			'wpbo-quantity-rule-tag-meta',
+			'Product Tags',
+			array( $this, 'quantity_rule_tag_meta' ),
+			'quantity-rule',
+			'normal',
 			'high'
 		);
 	}
-	
+
 	public function quantity_rule_tag_meta( $post ) {
-		
+
 		// Get all Tags
 		$args = array(
-		    'orderby'       => 'name', 
+		    'orderby'       => 'name',
 		    'order'         => 'ASC',
-		    'hide_empty'    => false, 
-	
-		); 
+		    'hide_empty'    => false,
+
+		);
 
 		$tags = get_terms( 'product_tag', $args );
-		
+
 		$included_tags = get_post_meta( $post->ID, '_tags');
 		if ( $included_tags != false ){
 			$included_tags = $included_tags[0];
@@ -328,7 +328,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 
 		// If Tags exists, show them all
 		if ( $tags ) {
-		
+
 			// Create Nonce Field
 			wp_nonce_field( plugin_basename( __FILE__ ), '_wpbo_tag_nonce' );
 
@@ -341,30 +341,30 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 						</li>
 					<?php endforeach; ?>
 				</ul>
-			<?php 
+			<?php
 		}
 	}
 
 	/*
 	*	Register and Create User Role Option for Quantity Rules
-	*/	
+	*/
 	public function quantity_rule_role_init() {
 		add_meta_box(
-			'wpbo-quantity-rule-role', 
-			'User Roles', 
-			array( $this, 'quantity_rule_role' ), 
-			'quantity-rule', 
-			'normal', 
+			'wpbo-quantity-rule-role',
+			'User Roles',
+			array( $this, 'quantity_rule_role' ),
+			'quantity-rule',
+			'normal',
 			'high'
 		);
 	}
-	
+
 	public function quantity_rule_role( $post ) {
 
 		// Get all user roles
 		global $wp_roles;
 		$roles = $wp_roles->get_names();
-		
+
 		// Get applied roles
 		$applied_roles = get_post_meta( $post->ID, '_roles' );
 		if ( $applied_roles != false ){
@@ -372,7 +372,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		}
 		// Create Nonce Field
 		wp_nonce_field( plugin_basename( __FILE__ ), '_wpbo_role_nonce' );
-		
+
 		if ( $roles ): ?>
 			<ul>
 				<?php foreach ( $roles as $slug => $name ): ?>
@@ -391,108 +391,108 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 
 	/*
 	*	Register and Create Meta Box to encourage user to install our thumbnail plugin
-	*/	
+	*/
 	public function input_thumbnail_notice() {
-	
+
 		// Only show meta box if user has not installed thumbnail plugin
 		if ( !in_array( 'woocommerce-thumbnail-input-quantities/woocommerce-thumbnail-input-quantity.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-		
-			add_meta_box(	
-				'wpbo-input-thumbnail-notice', 
-				'Urgent Notice', 
-				array( $this, 'input_thumbnail_notice_meta' ), 
-				'quantity-rule', 
-				'side', 
+
+			add_meta_box(
+				'wpbo-input-thumbnail-notice',
+				'Urgent Notice',
+				array( $this, 'input_thumbnail_notice_meta' ),
+				'quantity-rule',
+				'side',
 				'high'
 			);
 		}
 	}
-	
+
 	public function input_thumbnail_notice_meta( $post ) {
-		
+
 		echo "We've noticed you do not have <a href='http://wordpress.org/plugins/woocommerce-thumbnail-input-quantities/' target='_blank'>WooCommerce Thumbnail Input Quantity</a> installed. <br /><br />Installation is <strong>highly recommended</strong> as it shows an input box (with your quantity rules) from all product thumbnails such as on the shop page and in the related prodcuts section.";
-		
+
 	}
-	
+
 	/*
 	*	Register and Create Meta Box to encourage user to install our thumbnail plugin
-	*/	
+	*/
 	public function company_notice() {
-	
-		add_meta_box(	
-			'wpqu-company-notice', 
-			'Rapid Order', 
-			array( $this, 'company_notice_meta' ), 
-			'quantity-rule', 
-			'side', 
+
+		add_meta_box(
+			'wpqu-company-notice',
+			'Rapid Order',
+			array( $this, 'company_notice_meta' ),
+			'quantity-rule',
+			'side',
 			'low'
 		);
 	}
-	
+
 	public function company_notice_meta( $post ) {
-		
+
 		?>
 			<a href="http://rapidorderplugin.com/?utm_source=QU%20Plugin%20Admin&utm_medium=sidebar&utm_campaign=Fast%20order%20form%20for%20WooCommerce" target="_blank"><img align="center" src="<?php echo plugins_url() ?>/quantities-and-units-for-woocommerce/assets/img/rapid-order-logo.png" /></a>
 			<p>
 				<a href="http://rapidorderplugin.com/?utm_source=QU%20Plugin%20Admin&utm_medium=sidebar&utm_campaign=Fast%20order%20form%20for%20WooCommerce" target="_blank">Fast order form for WooCommerce</a>
 			</p>
-		<?php 
+		<?php
 	}
-	
+
 		/*
 	*	Register and Create Meta Box to encourage user to install our thumbnail plugin
-	*/	
+	*/
 	public function rate_us_notice() {
-	
-		add_meta_box(	
-			'wpbo-additional-info', 
-			'Additional Information', 
-			array( $this, 'additional_info_notice_meta' ), 
-			'quantity-rule', 
-			'side', 
+
+		add_meta_box(
+			'wpbo-additional-info',
+			'Additional Information',
+			array( $this, 'additional_info_notice_meta' ),
+			'quantity-rule',
+			'side',
 			'low'
 		);
 	}
-	
+
 	public function additional_info_notice_meta( $post ) {
 		?>
 			<div style="text-align: center">
 				<h3>Enjoy this plugin?</h3>
 				<a href="http://wordpress.org/support/view/plugin-reviews/quantities-and-units-for-woocommerce" target="_blank">Rate us on Wordpress.org!</a>
-			
+
 				<h3>Need Support?</h3>
-				<a href="http://wordpress.org/support/plugin/quantities-and-units-for-woocommerce" target="_blank">Visit our Support Forum</a> 
+				<a href="http://wordpress.org/support/plugin/quantities-and-units-for-woocommerce" target="_blank">Visit our Support Forum</a>
 			</div>
-		<?php 
+		<?php
 	}
-	
+
 	/*
 	*	Save Rule Meta Values
-	*/	
+	*/
 	public function save_quantity_rule_meta( $post_id ) {
-		
+
 		// Validate Post Type
 		if ( ! isset( $_POST['post_type'] ) or $_POST['post_type'] !== 'quantity-rule' ) {
 			return;
 		}
-		
+
 		// Validate User
 		if ( !current_user_can( 'edit_post', $post_id ) ) {
 	        return;
 	    }
-	
+
 		// Verify Nonce
 	    if ( ! isset( $_POST["_wpbo_rule_value_nonce"] ) or ! wp_verify_nonce( $_POST["_wpbo_rule_value_nonce"], plugin_basename( __FILE__ ) ) ) {
 	        return;
 	    }
-	
+
 		// Remove the rule/role transient
 		global $wp_roles;
 		$roles = $wp_roles->get_names();
 		foreach ( $roles as $slug => $name ) {
 			delete_transient( 'ipq_rules_' . $slug );
 		}
-	
+
 		//Also delete the guest transient, which is not a role
 
 		delete_transient( 'ipq_rules_guest' );
@@ -501,188 +501,188 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		if( isset( $_POST['min'] ) ) {
 			$min = $_POST['min'];
 		}
-		
-		// Update Step 
+
+		// Update Step
 		if ( isset( $_POST['step'] ) and isset( $min ) ) {
 			if ( $min < $_POST['step'] && $min > 0) {
 				$min = $_POST['step'];
 			}
 		}
-		
+
 		// Get Min Out of Stock
 		if( isset( $_POST['min_oos'] ) ) {
 			$min_oos = $_POST['min_oos'];
 			update_post_meta( $post_id, '_min_oos', stripslashes( $min_oos ) );
 		}
-		
+
 		// Update Min
 		if ( isset( $min ) ) {
 			update_post_meta( $post_id, '_min', stripslashes( $min ) );
 		}
-		
+
 		// Update Max
 		if ( isset( $_POST['max'] ) ) {
 			$max = $_POST['max'];
-			
+
 			// Validate Max is not less then Min
 			if ( isset( $min ) and $max < $min and $max != 0 ) {
 				$max = $min;
 			}
-			
+
 			update_post_meta( $post_id, '_max', wcqu_validate_number( $max ) );
 		}
-		
+
 		// Update Max OOS
 		if ( isset( $_POST['max_oos'] ) ) {
 			$max_oos = $_POST['max_oos'];
-				
+
 			// Max must be bigger then min
 			if ( $max_oos != '' and isset( $min_oos ) and $min_oos != 0 ) {
 				if ( $min_oos > $max_oos )
 					$max_oos = $min_oos;
-				
+
 			} elseif ( $max_oos != '' and isset( $min ) and $min != 0 ){
 				if ( $min > $max_oos ) {
 					$max_oos = $min;
 				}
 			}
-				
+
 			update_post_meta( $post_id, '_max_oos', wcqu_validate_number( $max_oos ) );
 		}
-		
+
 		// Update Step
 		if ( isset( $_POST['step'] ) ) {
 			update_post_meta( $post_id, '_step', wcqu_validate_number( $_POST['step'] ) );
 		}
-		
+
 		// Update Priority
 		if ( isset( $_POST['priority'] ) ) {
 			update_post_meta( $post_id, '_priority', wcqu_validate_number( $_POST['priority'] ) );
 		}
-		
+
 	}
-	
+
 	/*
 	*	Save Rule Taxonomy Values
-	*/	
+	*/
 	public function save_quantity_rule_taxes( $post_id ) {
-		
+
 		// Validate Post Type
 		if ( ! isset( $_POST['post_type'] ) or $_POST['post_type'] !== 'quantity-rule' ) {
 			return;
 		}
-		
+
 		// Validate User
 		if ( !current_user_can( 'edit_post', $post_id ) ) {
 	        return;
 	    }
-	
+
 		// Verify Nonce
 	    if ( ! isset( $_POST["_wpbo_tax_nonce"] ) or ! wp_verify_nonce( $_POST["_wpbo_tax_nonce"], plugin_basename( __FILE__ ) ) ) {
 	        return;
 	    }
-	
+
 		// Check which Categories have been selected
 		$tax_name = 'product_cat';
 		$args = array( 'hide_empty' => false );
 		$terms = get_terms( $tax_name, $args );
 		$cats = array();
-	
+
 		// See which terms were included
 		foreach ( $terms as $term ) {
 			$term_name = '_wpbo_cat_' . $term->term_id;
 			if ( isset( $_POST[ $term_name ] ) and $_POST[ $term_name ] == 'on' ) {
-				array_push( $cats, $term->term_id );		
-			} 
+				array_push( $cats, $term->term_id );
+			}
 		}
-		
+
 		// Add them to the post meta
 		delete_post_meta( $post_id, '_cats' );
 		update_post_meta( $post_id, '_cats', $cats, false );
-	} 
-	
+	}
+
 	/*
 	*	Save Rule Tag Values
-	*/	
+	*/
 	public function save_quantity_rule_tags( $post_id ) {
-		
+
 		// Validate Post Type
 		if ( ! isset( $_POST['post_type'] ) or $_POST['post_type'] !== 'quantity-rule' ) {
 			return;
 		}
-		
+
 		// Validate User
 		if ( !current_user_can( 'edit_post', $post_id ) ) {
 	        return;
 	    }
-	
+
 		// Verify Nonce
 	    if ( ! isset( $_POST["_wpbo_tag_nonce"] ) or ! wp_verify_nonce( $_POST["_wpbo_tag_nonce"], plugin_basename( __FILE__ ) ) ) {
 	        return;
 	    }
-	    
+
 	    // Get all Tags
 		$args = array (
-		    'orderby'       => 'name', 
+		    'orderby'       => 'name',
 		    'order'         => 'ASC',
-		    'hide_empty'    => false, 
-		); 
+		    'hide_empty'    => false,
+		);
 
 		$tags = get_terms( 'product_tag', $args );
-		
+
 		$tags_included = array();
-		
+
 		// If the tags are set, loop through them
 		if ( $tags ) {
 			foreach ( $tags as $tag ) {
-				
+
 				$tag_name = '_wpbo_tag_' . $tag->term_id;
 				if ( isset( $_POST[ $tag_name ] ) and $_POST[ $tag_name ] == 'on' ) {
-					array_push( $tags_included, $tag->term_id );		
-				} 
+					array_push( $tags_included, $tag->term_id );
+				}
 			}
-			
+
 			// Add them to the post meta
 			delete_post_meta( $post_id, '_tags' );
 			update_post_meta( $post_id, '_tags', $tags_included, false );
 		}
 	}
-	
+
 	/*
 	*	Save Rule Role Values
-	*/	
+	*/
 	public function save_quantity_rule_roles( $post_id ) {
-		
+
 		// Validate Post Type
 		if ( ! isset( $_POST['post_type'] ) or $_POST['post_type'] !== 'quantity-rule' ) {
 			return;
 		}
-		
+
 		// Validate User
 		if ( !current_user_can( 'edit_post', $post_id ) ) {
 	        return;
 	    }
-	
+
 		// Verify Nonce
 	    if ( ! isset( $_POST["_wpbo_role_nonce"] ) or ! wp_verify_nonce( $_POST["_wpbo_role_nonce"], plugin_basename( __FILE__ ) ) ) {
 	        return;
 	    }
-	    
+
 	    // Get available user roles
 	    global $wp_roles;
 		$roles = $wp_roles->get_names();
 		$applied_roles = array();
-		
+
 		// Loop through roles
 		foreach ( $roles as $slug => $name ) {
 			$role_name = '_wpbo_role_' . $slug;
-			
+
 			// If role is set add it to the applied list
 			if ( isset( $_POST[ $role_name ] ) and $_POST[ $role_name ] == 'on' ) {
 				array_push( $applied_roles, $slug );
 			}
 		}
-		
+
 		// If guest role is set add it to the applied list
 		if ( isset( $_POST[ '_wpbo_role_guest' ] ) and $_POST[ '_wpbo_role_guest' ] == 'on' ) {
 			array_push( $applied_roles, 'guest' );
@@ -692,8 +692,8 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		// Add them to the post meta
 		delete_post_meta( $post_id, '_roles' );
 		update_post_meta( $post_id, '_roles', $applied_roles, false );
-    
-	}	
+
+	}
 }
 
 endif;

--- a/includes/class-wcqu-product-meta-box.php
+++ b/includes/class-wcqu-product-meta-box.php
@@ -1,12 +1,12 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units_Quantity_Meta_Boxes' ) ) :
 
 class WC_Quantities_and_Units_Quantity_Meta_Boxes {
-	
+
 	public function __construct() {
-		
+
 		add_action( 'add_meta_boxes', array( $this, 'meta_box_create' ) );
 		add_action( 'save_post', array( $this, 'save_quantity_meta_data' ) );
 	}
@@ -18,24 +18,24 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		global $post, $woocommerce;
 
 		if ( $post->post_type == 'product' ) {
-			
-			$product = get_product( $post->ID );
+
+			$product = wc_get_product( $post->ID );
 			$unsupported_product_types = array( 'external', 'grouped' );
 
-			if ( ! in_array( $product->product_type, $unsupported_product_types ) ) {
-						
+			if ( ! in_array( $product->get_type(), $unsupported_product_types ) ) {
+
 				add_meta_box(
-					'wpbo_product_info', 
-					__('Product Quantity Rules', 'woocommerce'), 
-					array( $this, 'product_meta_box_content' ), 
-					'product', 
-					'normal', 
-					'high' 
+					'wpbo_product_info',
+					__('Product Quantity Rules', 'woocommerce'),
+					array( $this, 'product_meta_box_content' ),
+					'product',
+					'normal',
+					'low'
 				);
 			}
 		}
 	}
-	
+
 	/*
 	*	Display Rule Meta Box
 	*/
@@ -43,14 +43,14 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		global $product;
 		global $woocommerce;
 		global $wp_roles;
-				
+
 		// Get the product and see what rules are being applied
 		$pro = wc_get_product( $post );
-		
+
 		// Get applied rules by user role
 		$roles = $wp_roles->get_names();
 		$roles['guest'] = "Guest";
-		
+
 		$rules_by_role = array();
 
 		$rule = null;
@@ -64,17 +64,17 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 
 			if ( $newRule == 'inactive' or $newRule == 'override' or $newRule == 'sitewide' )
 				continue;
-				
+
 			$rules_by_role[$name] = $newRule;
 		}
-		
+
 		// Display Rule Being Applied
 		if ( $rule == 'inactive' ) {
 			echo "<div class='inactive-rule rule-message'>No rule is being applied becasue you've deactivated the plugin for this product.</div>";
-			
+
 		} elseif ( $rule == 'override' ) {
 			echo "<div class='overide-rule rule-message'>The values below are being used because you've chosen to override any applied rules for this product.</div>";
-		
+
 		} elseif ( $rule == 'sitewide' ) {
 			?>
 			<?php $values = wcqu_get_value_from_rule( 'all', $pro, $rule ); ?>
@@ -85,8 +85,8 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 				</a>
 				<span class='active-toggle'><a>Show/Hide Active Rules by Role &#x25BC;</a></span>
 			</div>
-	
-			<div class="rule-meta">		
+
+			<div class="rule-meta">
 				<table>
 					<tr>
 						<th>Role</th>
@@ -110,10 +110,10 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 					</tr>
 				</table>
 			</div>
-			<?php 
+			<?php
 		} elseif ( (! isset( $rule->post_title ) or $rule->post_title == null) ) {
 			echo "<div class='no-rule rule-message'>No rule is currently being applied to this product.</div>";
-			
+
 		} else { ?>
 			<div class="active-rule">
 				<span>Active Rule:</span>
@@ -125,8 +125,8 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 				<?php endforeach; ?>
 				<span class='active-toggle'><a>Show/Hide Active Rules by Role &#x25BC;</a></span>
 			</div>
-	
-			<div class="rule-meta">		
+
+			<div class="rule-meta">
 				<table>
 					<tr>
 						<th>Role</th>
@@ -140,7 +140,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 					</tr>
 				<?php foreach ( $rules_by_role as $role => $rule ): ?>
 					<?php if ( $rule != null )
-						$values = wcqu_get_value_from_rule( 'all', $pro, $rule ); 
+						$values = wcqu_get_value_from_rule( 'all', $pro, $rule );
 					?>
 					<tr>
 						<td><?php echo $role ?></td>
@@ -149,7 +149,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 							<td><?php echo $values['min_value'] ?></td>
 							<td><?php echo $values['max_value'] ?></td>
 							<td><?php echo $values['min_oos'] ?></td>
-							<td><?php echo $values['max_oos'] ?></td>							
+							<td><?php echo $values['max_oos'] ?></td>
 							<td><?php echo $values['step'] ?></td>
 							<td><?php echo $values['priority'] ?></td>
 						<?php else: ?>
@@ -167,7 +167,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 			</div>
 		<?php
 		}
-	
+
 		// Get the current values if they exist
 		$deactive  = get_post_meta( $post->ID, '_wpbo_deactive', true );
 		$step  = get_post_meta( $post->ID, '_wpbo_step',     true );
@@ -176,99 +176,99 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		$over  = get_post_meta( $post->ID, '_wpbo_override', true );
 		$min_oos = get_post_meta( $post->ID, '_wpbo_minimum_oos', true );
 		$max_oos = get_post_meta( $post->ID, '_wpbo_maximum_oos', true );
-		
+
 		// Create Nonce Field
 		wp_nonce_field( plugin_basename( __FILE__ ), '_wpbo_product_rule_nonce' );
-		
-		// Print the form ?>	
+
+		// Print the form ?>
 		<div class="rule-input-boxes">
 			<input type="checkbox" name="_wpbo_deactive" <?php if ( $deactive == 'on' ) echo 'checked'; ?> />
 			<span>Deactivate Quantity Rules on this Product?</span>
-			
+
 			<input type="checkbox" name="_wpbo_override" id='toggle_override' <?php if ( $over == 'on' ) echo 'checked'; ?> />
 			<span>Override Quantity Rules with Values Below</span>
-			
+
 			<span class='wpbo_product_values' <?php if ( $over != 'on' ) echo "style='display:none'"?>>
 				<label for="_wpbo_step">Step Value</label>
 				<input type="number" name="_wpbo_step" value="<?php echo $step; ?>" step="any" />
-				
+
 				<label for="_wpbo_minimum">Minimum Quantity</label>
 				<input type="number" name="_wpbo_minimum" value="<?php echo $min; ?>" step="any" />
-				
+
 				<label for="_wpbo_maximum">Maximum Quantity</label>
 				<input type="number" name="_wpbo_maximum" value="<?php echo $max; ?>" step="any" />
-				
+
 				<label for="_wpbo_minimum_oos">Out of Stock Minimum</label>
 				<input type="number" name="_wpbo_minimum_oos" value="<?php echo $min_oos ?>" step="any" />
-				
+
 				<label for="_wpbo_maximum_oos">Out of Stock Maximum</label>
 				<input type="number" name="_wpbo_maximum_oos" value="<?php echo $max_oos ?>" step="any" />
-				
+
 				<span class='clear-left'>Note* Maximum values must be larger then minimums</span>
 			</span>
 
 		</div>
 		<?php
 	}
-	
+
 	/*
 	*	Handle Saving Meta Box Data
-	*/	
+	*/
 	public function save_quantity_meta_data( $post_id ) {
-	
+
 		// Validate Post Type
 		if ( ! isset( $_POST['post_type'] ) or $_POST['post_type'] !== 'product' ) {
 			return;
 		}
-		
+
 		// Validate User
 		if ( !current_user_can( 'edit_post', $post_id ) ) {
 	        return;
 	    }
-	    
+
 	    // Verify Nonce
 	    if ( ! isset( $_POST["_wpbo_product_rule_nonce"] ) or ! wp_verify_nonce( $_POST["_wpbo_product_rule_nonce"], plugin_basename( __FILE__ ) ) ) {
 	        return;
 	    }
-	
+
 		// Update Rule Meta Values
 		if( isset( $_POST['_wpbo_deactive'] )) {
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_deactive', 
+			update_post_meta(
+				$post_id,
+				'_wpbo_deactive',
 				strip_tags( $_POST['_wpbo_deactive'] )
 			);
-			
+
 		} else {
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_deactive', 
-				'' 
+			update_post_meta(
+				$post_id,
+				'_wpbo_deactive',
+				''
 			);
 		}
-	
+
 		if( isset( $_POST['_wpbo_override'] )) {
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_override', 
+			update_post_meta(
+				$post_id,
+				'_wpbo_override',
 				strip_tags( $_POST['_wpbo_override'] )
 			);
 		} else {
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_override', 
-				'' 
+			update_post_meta(
+				$post_id,
+				'_wpbo_override',
+				''
 			);
 		}
-		
+
 		if ( isset( $_POST['_wpbo_minimum'] )) {
 			$min  = $_POST['_wpbo_minimum'];
 		}
-		
+
 		if ( isset( $_POST['_wpbo_step'] )) {
 			$step = $_POST['_wpbo_step'];
 		}
-		
+
 		/* Make sure min >= step */
 		/*
 		if ( isset( $step ) and isset( $min ) ) {
@@ -277,87 +277,87 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 			}
 		}
 		*/
-		
+
 		if( isset( $_POST['_wpbo_step'] )) {
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_step', 
+			update_post_meta(
+				$post_id,
+				'_wpbo_step',
 				strip_tags( wcqu_validate_number( $_POST['_wpbo_step'] ) )
 			);
 		}
-		
+
 		if( isset( $_POST['_wpbo_minimum'] )) {
 			if ( $min != 0 ) {
 				$min = wcqu_validate_number( $min );
 			}
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_minimum', 
+			update_post_meta(
+				$post_id,
+				'_wpbo_minimum',
 				strip_tags( $min )
 			);
 		}
-		
+
 		/* Make sure Max > Min */
 		if( isset( $_POST['_wpbo_maximum'] )) {
 			$max = $_POST['_wpbo_maximum'];
 			if ( isset( $min ) and $max < $min and $max != 0 ) {
 				$max = $min;
 			}
-		
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_maximum', 
+
+			update_post_meta(
+				$post_id,
+				'_wpbo_maximum',
 				strip_tags( wcqu_validate_number( $max ) )
 			);
 		}
-		
+
 		// Update Out of Stock Minimum
 		if( isset( $_POST['_wpbo_minimum_oos'] )) {
 			$min_oos = stripslashes( $_POST['_wpbo_minimum_oos'] );
-			
+
 			if ( $min_oos != 0 ) {
 				$min_oos = wcqu_validate_number( $min_oos );
 			}
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_minimum_oos', 
+			update_post_meta(
+				$post_id,
+				'_wpbo_minimum_oos',
 				strip_tags( $min_oos )
 			);
 		}
-		
+
 		// Update Out of Stock Maximum
 		if( isset( $_POST['_wpbo_maximum_oos'] )) {
-		
+
 			$max_oos = stripslashes( $_POST['_wpbo_maximum_oos'] );
-			
+
 			// Allow the value to be unset
 			if ( $max_oos != '' ) {
-				
-				// Validate the number			
+
+				// Validate the number
 				if ( $max_oos != 0 ) {
 					$max_oos = wcqu_validate_number( $max_oos );
-				} 
-				
+				}
+
 				// Max must be bigger then min
 				if ( isset( $min_oos ) and $min_oos != 0 ) {
 					if ( $min_oos > $max_oos )
 						$max_oos = $min_oos;
-					
+
 				} elseif ( isset( $min ) and $min != 0 ){
 					if ( $min > $max_oos ) {
 						$max_oos = $min;
 					}
 				}
-			} 
-			
-			update_post_meta( 
-				$post_id, 
-				'_wpbo_maximum_oos', 
+			}
+
+			update_post_meta(
+				$post_id,
+				'_wpbo_maximum_oos',
 				strip_tags( $max_oos )
 			);
 
-		} 
-		
+		}
+
 	}
 }
 

--- a/includes/class-wcqu-product-unit.php
+++ b/includes/class-wcqu-product-unit.php
@@ -61,7 +61,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 */
 	public function get_price_suffix( $price_display_suffix, $product ) {
 		// todo make default unit configuarble
-		if ( $unit = $this->get_unit_for_product( $product->id, apply_filters( 'wciu_default_price_suffix', __( '', 'woocommerce' ) ) ) ) {
+		if ( $unit = $this->get_unit_for_product( $product->get_id(), apply_filters( 'wciu_default_price_suffix', __( '', 'woocommerce' ) ) ) ) {
 			$price_display_suffix = "/" . $unit . " " . $price_display_suffix;
 		}
 
@@ -77,7 +77,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 * @return  string
 	 */
 	public function sale_price_from_to( $price, $from, $to, $product ) {
-		if ( $unit = get_post_meta( $product->id, 'unit', true ) ) {
+		if ( $unit = get_post_meta( $product->get_id(), 'unit', true ) ) {
 			$price = '<del>' . ( ( is_numeric( $from ) ) ? wc_price( $from ) : $from ) . '/' . $unit . '</del> <ins>' . ( ( is_numeric( $to ) ) ? wc_price( $to ) : $to ) . '/' . $unit . '</ins>';
 		}
 
@@ -91,7 +91,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 * @return  string
 	 */
 	public function price_html( $html, $product ) {
-		$unit = get_post_meta( $product->id, 'unit', true );
+		$unit = get_post_meta( $product->get_id(), 'unit', true );
 		if ( $unit ) {
 			return $html . '/' . $unit;
 		}

--- a/includes/class-wcqu-units-box.php
+++ b/includes/class-wcqu-units-box.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WC_Quantities_and_Units_Units_Box' ) ) :
 
 	class WC_Quantities_and_Units_Units_Box {
 		public function __construct() {
-			add_action( 'woocommerce_product_write_panels', array( $this, 'units_box_create' ) );
+			add_action( 'woocommerce_product_data_panels', array( $this, 'units_box_create' ) );
 			add_action( 'save_post', array( $this, 'save_unit_meta_data' ) );
 			add_action( 'woocommerce_product_write_panel_tabs', array($this, 'units_box_tab'), 99 );
 		}

--- a/includes/class-wcqu-validations.php
+++ b/includes/class-wcqu-validations.php
@@ -1,12 +1,12 @@
-<?php 
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units_Quantity_Validations' ) ) :
 
 class WC_Quantities_and_Units_Quantity_Validations {
-	
+
 	public function __construct() {
-	
+
 		add_action( 'woocommerce_add_to_cart_validation', array( $this, 'add_to_cart_validation' ), 5, 6 );
 		add_action( 'woocommerce_update_cart_validation', array( $this, 'update_cart_validation' ), 5, 5 );
 
@@ -15,7 +15,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 	/*
 	*	Add to Cart Validation to ensure quantity ordered follows the user's rules.
 	*
-	*	@access public 
+	*	@access public
 	*	@param  boolean passed
 	*	@param  int		product_id
 	*	@param  int 	quantity
@@ -29,13 +29,13 @@ class WC_Quantities_and_Units_Quantity_Validations {
 	public function add_to_cart_validation( $passed, $product_id, $quantity, $variation_id = null, $variations = null, $cart_item_key = null ) {
 
 		return $this->validate_single_product( $passed, $product_id, $quantity, false, $variation_id, $variations );
-		
+
 	}
-	
+
 	/*
 	*	Cart Update Validation to ensure quantity ordered follows the user's rules.
 	*
-	*	@access public 
+	*	@access public
 	*	@param  boolean passed
 	*	@param  string	cart_item_key
 	*	@param  array 	values
@@ -46,14 +46,14 @@ class WC_Quantities_and_Units_Quantity_Validations {
 	public function update_cart_validation( $passed, $cart_item_key, $values, $quantity ) {
 
 		return $this->validate_single_product( $passed, $values['product_id'], $quantity, true, $values['variation_id'], $values['variation'] );
-		
+
 	}
-	
+
 	/*
 	*	Validates a single product based on the quantity rules applied to it.
 	*	It will also validate based on the quantity in the cart.
 	*
-	*	@access public 
+	*	@access public
 	*	@param  boolean passed
 	*	@param  int		product_id
 	*	@param  int 	quantity
@@ -61,66 +61,66 @@ class WC_Quantities_and_Units_Quantity_Validations {
 	*	@param  int 	variation_id
 	*	@param  array	variations
 	*	@return boolean
-	*	
+	*
 	*/
 	public function validate_single_product( $passed, $product_id, $quantity, $from_cart, $variation_id = null, $variations = null ) {
 		global $woocommerce, $product, $WC_Quantities_and_Units;
-		
+
 		$product = wc_get_product( $product_id );
 		$title = $product->get_title();
-	
+
 		// Get the applied rule and values - if they exist
 		$rule = wcqu_get_applied_rule( $product );
 		$values = wcqu_get_value_from_rule( 'all', $product, $rule );
-		
+
 		if ( $values != null )
 			extract( $values ); // $min_value, $max_value, $step, $priority, $min_oos, $max_oos
-				
+
 		// Inactive Products can be ignored
 		if ( $values == null )
 			return true;
-	
-		// Check if the product is out of stock 
+
+		// Check if the product is out of stock
 		$stock = $product->get_stock_quantity();
-	
+
 		// Adjust min value if item is out of stock
 		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $min_oos ) and $min_oos != null  ) {
 			$min_value = $min_oos;
 		}
-		
+
 		// Adjust max value if item is out of stock
 		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $max_oos ) and $max_oos != null ) {
 			$max_value = $max_oos;
 		}
-		
+
 		// Min Validation
 		// added $min_value != 0 since List Items starts all products at 0 quantity.
 		if ( $min_value != null && $min_value != 0 && $quantity < $min_value ) {
-			
+
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You must add a minimum of %s %s's to your cart.", 'woocommerce' ), $min_value, $title ), 'error' );
-			
-			// Old Validation Style Support	
+
+			// Old Validation Style Support
 			} else {
 				$woocommerce->add_error( sprintf( __( "You must add a minimum of %s %s's to your cart.", 'woocommerce' ), $min_value, $title ) );
 			}
-			
+
 			return false;
 		}
-	
+
 		// Max Validation
 		if ( $max_value != null && $quantity > $max_value ) {
-			
+
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You may only add a maximum of %s %s's to your cart.", 'woocommerce' ), $max_value, $title ), 'error' );
-			
-			// Old Validation Style Support	
+
+			// Old Validation Style Support
 			} else {
 				$woocommerce->add_error( sprintf( __( "You may only add a maximum of %s %s's to your cart.", 'woocommerce' ), $max_value, $title ) );
 			}
 			return false;
 		}
-		
+
 		// Subtract the min value from quantity to calc remainder if min value exists
 		if ( $min_value != 0 ) {
 			$rem_qty = $quantity - $min_value;
@@ -130,75 +130,75 @@ class WC_Quantities_and_Units_Quantity_Validations {
 
 		$rem_qty = (float)$rem_qty;
 		$step = (float)$step;
-		
-		// Step Validation	
+
+		// Step Validation
 		if ( $step != null && wcqu_fmod_round($rem_qty, $step) != 0 ) {
-		
+
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You may only add a %s in multiples of %s to your cart.", 'woocommerce' ), $title, $step ), 'error' );
-			
-			// Old Validation Style Support	
+
+			// Old Validation Style Support
 			} else {
 				$woocommerce->add_error( sprintf( __( "You may only add a %s in multiples of %s to your cart.", 'woocommerce' ), $title, $step ) );
 			}
-			
+
 			return false;
 		}
-		
+
 		// Don't run Cart Validations if user is updating the cart
 		if ( $from_cart != true ) {
-		
+
 			// Get Cart Quantity for the product
 			foreach( $woocommerce->cart->get_cart() as $cart_item_key => $values ) {
 				$_product = $values['data'];
-				if( $product_id == $_product->id ) {
+				if( $product_id == $_product->get_id() ) {
 					$cart_qty = $values['quantity'];
 				}
 			}
-			
+
 			//  If there aren't any items in the cart already, ignore these validations
 			if ( isset( $cart_qty ) and $cart_qty != null ) {
-			
+
 				// Total Cart Quantity Min Validation
 				if ( $min_value != null && ( $quantity + $cart_qty ) < $min_value ) {
-					
+
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __( "Your cart must have a minimum of %s %s's to proceed.", 'woocommerce' ), $min_value, $title ), 'error' );
-					
-					// Old Validation Style Support	
+
+					// Old Validation Style Support
 					} else {
 						$woocommerce->add_error( sprintf( __( "Your cart must have a minimum of %s %s's to proceed.", 'woocommerce' ), $min_value, $title ) );
 					}
 					return false;
 				}
-			
+
 				// Total Cart Quantity Max Validation
 				if ( $max_value != null && ( $quantity + $cart_qty ) > $max_value ) {
-					
+
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __( "You can only purchase a maximum of %s %s's at once and your cart has %s %s's in it already.", 'woocommerce' ), $max_value, $title, $cart_qty, $title ), 'error' );
-					
-					// Old Validation Style Support	
+
+					// Old Validation Style Support
 					} else {
 						$woocommerce->add_error( sprintf( __( "You can only purchase a maximum of %s %s's at once and your cart has %s %s's in it already.", 'woocommerce' ), $max_value, $title, $cart_qty, $title ) );
 					}
 					return false;
 				}
-				
+
 				// Subtract the min value from cart quantity to calc remainder if min value exists
 				if ( $min_value != 0 ) {
 					$cart_qty_rem = $quantity + $cart_qty - $min_value;
 				} else {
 					$cart_qty_rem = $quantity + $cart_qty;
 				}
-				
+
 				// Total Cart Quantity Step Validation
 				$cart_qty_rem = (float)$cart_qty_rem;
 				if ( $step != null && $step != 0 && $cart_qty_rem != 0 && wcqu_fmod_round($cart_qty_rem, $step) != 0 ) {
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __("You may only purchase %s in multiples of %s.", 'woocommerce' ), $title, $step ), 'error' );
-					
-					// Old Validation Style Support	
+
+					// Old Validation Style Support
 					} else {
 						$woocommerce->add_error( sprintf( __("You may only purchase %s in multiples of %s.", 'woocommerce' ), $title, $step ) );
 					}

--- a/includes/wcqu-functions.php
+++ b/includes/wcqu-functions.php
@@ -1,27 +1,27 @@
-<?php 
+<?php
 /*
 *	Given the product, this will check which rule is being applied to a product
-* 	If there is a rule, the values will be returned otherwise it is inactive 
+* 	If there is a rule, the values will be returned otherwise it is inactive
 *	or overridden (from the product meta box).
 *
 *	@params object	$product WC_Product object
 *	@param 	string	User role to get rule from, otherwise current user role is used
-*	@return mixed 	String of rule status / Object top rule post 
+*	@return mixed 	String of rule status / Object top rule post
 */
 function wcqu_get_applied_rule( $product, $role = null ) {
-	
+
 	// Check for site wide rule
 	$options = get_option( 'ipq_options' );
-	
-	if ( get_post_meta( $product->id, '_wpbo_deactive', true ) == 'on' ) {
+
+	if ( get_post_meta( $product->get_id(), '_wpbo_deactive', true ) == 'on' ) {
 		return 'inactive';
-		
-	} elseif ( get_post_meta( $product->id, '_wpbo_override', true ) == 'on' ) {
+
+	} elseif ( get_post_meta( $product->get_id(), '_wpbo_override', true ) == 'on' ) {
 		return 'override';
-	
+
 	} elseif ( isset( $options['ipq_site_rule_active'] ) and $options['ipq_site_rule_active'] == 'on' ) {
 		return 'sitewide';
-		
+
 	} else {
 		return wcqu_get_applied_rule_obj( $product, $role );
 	}
@@ -33,13 +33,13 @@ function wcqu_get_applied_rule( $product, $role = null ) {
 *
 *	@params object	$product WC_Product object
 *	@param 	string	User role to get rule from, otherwise current user role is used
-*	@return mixed 	Null if no rule applies / Object top rule post 
+*	@return mixed 	Null if no rule applies / Object top rule post
 */
 function wcqu_get_applied_rule_obj( $product, $role = null ) {
-	
+
 	// Get Product Terms
-	$product_cats = wp_get_post_terms( $product->id, 'product_cat' );
-	$product_tags = wp_get_post_terms( $product->id, 'product_tag' );	
+	$product_cats = wp_get_post_terms( $product->get_id(), 'product_cat' );
+	$product_tags = wp_get_post_terms( $product->get_id(), 'product_tag' );
 
 	// Get role if not passed
 	if(!is_user_logged_in()) {
@@ -62,49 +62,49 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 			'posts_per_page'   	=> -1,
 			'post_type'        	=> 'quantity-rule',
 			'post_status'      	=> 'publish',
-		); 
-		
+		);
+
 		$rules = get_posts( $args );
-		
+
 		// Remove rules not applied to current user role
-		$cnt = 0; 
+		$cnt = 0;
 		$rules_to_unset = array();
-		
+
 		while ( $cnt < count( $rules ) ) {
-	
+
 			$roles = get_post_meta( $rules[$cnt]->ID, '_roles' );
 		 	if ( !in_array( $role, $roles[0] ) && !empty($roles[0])) {
 			 	array_push( $rules_to_unset, $cnt );
-		 	} 
-		 	
+		 	}
+
 		 	$cnt++;
-		}		
+		}
 
 		$duration = 60 * 60 * 12; // 12 hours
 		arsort( $rules_to_unset );
-		
+
 		foreach ( $rules_to_unset as $single_unset ) {
 			unset( $rules[$single_unset] );
-		}		
-		set_transient( 'ipq_rules_' . $role, $rules, $duration );	
-	} 
+		}
+		set_transient( 'ipq_rules_' . $role, $rules, $duration );
+	}
 
 	$top = null;
 	$top_rule = null;
 
 	// Loop through the rules and find the ones that apply
 	foreach ( $rules as $rule ) {
-	 
+
 	 	$apply_rule = false;
-	 	
+
 	 	// Get the Rule's Cats and Tags
 	 	$cats = get_post_meta( $rule->ID, '_cats' );
 	 	$tags = get_post_meta( $rule->ID, '_tags' );
 	 	$roles = get_post_meta( $rule->ID, '_roles' );
-	 		 	
+
 	 	if( $cats != false )
 		 	$cats = $cats[0];
-	 	
+
 	 	if( $tags != false )
 		 	$tags = $tags[0];
 
@@ -120,11 +120,11 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 			 	$apply_rule = true;
 		 	}
 	 	}
-	 	
+
 	 	// If the rule applies, check the priority
 	 	if ( $apply_rule == true ) {
-	 	
-	 		$priority = get_post_meta( $rule->ID, '_priority', true );	
+
+	 		$priority = get_post_meta( $rule->ID, '_priority', true );
 
 	 		if( $priority != '' and $top > $priority or $top == null ) {
 	 			$top = $priority;
@@ -132,106 +132,106 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 		 	}
 		}
 	}
-	
-	return $top_rule;	
+
+	return $top_rule;
 }
 
 /*
 *	Get the Input Value (min/max/step/priority/role/all) for a product given a rule
 *
 *	@params string	$type Product type
-*	@params object 	$product Product Object 
+*	@params object 	$product Product Object
 *	@params object	$rule Quantity Rule post object
 *	@return mixed
 */
 function wcqu_get_value_from_rule( $type, $product, $rule ) {
 
 	// Validate $type
-	if ( $type != 'min' and 
-		 $type != 'max' and 
-		 $type != 'step' and 
-		 $type != 'all' and 
-		 $type != 'priority' and 
+	if ( $type != 'min' and
+		 $type != 'max' and
+		 $type != 'step' and
+		 $type != 'all' and
+		 $type != 'priority' and
 		 $type != 'role' and
 		 $type != 'min_oos' and
 		 $type != 'max_oos'
 		) {
 		return null;
-	
-	// Validate for missing rule	
+
+	// Validate for missing rule
 	} elseif ( $rule == null ) {
 		return null;
-	
+
 	// Return Null if Inactive
 	} elseif ( $rule == 'inactive' ) {
 		return null;
-	
+
 	// Return Product Meta if Override is on
 	} elseif ( $rule == 'override' ) {
-		
+
 		// Check if the product is out of stock
 		$stock = $product->get_stock_quantity();
 
 		// Check if the product is under stock management and out of stock
 		if ( strlen( $stock ) != 0 and $stock <= 0 ) {
-			
+
 			// Return Out of Stock values if they exist
 			switch ( $type ) {
 				case 'min':
-					$min_oos = get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+					$min_oos = get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 					if ( $min_oos != '' )
 						return $min_oos;
 					break;
-				
+
 				case 'max':
-					$max_oos = get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+					$max_oos = get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 					if ( $max_oos != '' )
 						return $max_oos;
-					break;	
-			}  
+					break;
+			}
 			// If nothing was returned, proceed as usual
 		}
-		
+
 		switch ( $type ) {
 			case 'all':
-				return array( 
-						'min_value' => get_post_meta( $product->id, '_wpbo_minimum', true ),
-						'max_value' => get_post_meta( $product->id, '_wpbo_maximum', true ),
-						'step' 		=> get_post_meta( $product->id, '_wpbo_step', true ),
-						'min_oos'	=> get_post_meta( $product->id, '_wpbo_minimum_oos', true ),
-						'max_oos'	=> get_post_meta( $product->id, '_wpbo_maximum_oos', true ),
+				return array(
+						'min_value' => get_post_meta( $product->get_id(), '_wpbo_minimum', true ),
+						'max_value' => get_post_meta( $product->get_id(), '_wpbo_maximum', true ),
+						'step' 		=> get_post_meta( $product->get_id(), '_wpbo_step', true ),
+						'min_oos'	=> get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true ),
+						'max_oos'	=> get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true ),
 					);
 				break;
 			case 'min':
-				return get_post_meta( $product->id, '_wpbo_minimum', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum', true );
 				break;
-			
-			case 'max': 
-				return get_post_meta( $product->id, '_wpbo_maximum', true );
+
+			case 'max':
+				return get_post_meta( $product->get_id(), '_wpbo_maximum', true );
 				break;
-				
+
 			case 'step':
-				return get_post_meta( $product->id, '_wpbo_step', true );
+				return get_post_meta( $product->get_id(), '_wpbo_step', true );
 				break;
-			
+
 			case 'min_oos':
-				return get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 				break;
-			
+
 			case 'max_oos':
-				return get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 				break;
-				
+
 			case 'priority':
 				return null;
 				break;
-		}		
-	
+		}
+
 	// Check for Site Wide Rule
 	} elseif ( $rule == 'sitewide' ) {
 
 		$options = get_option( 'ipq_options' );
-		
+
 		if( isset( $options['ipq_site_min'] ) ) {
 			$min = $options['ipq_site_min'];
 		} else {
@@ -249,62 +249,62 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 		} else {
 			$min_oos = '';
 		}
-		
+
 		if( isset( $options['ipq_site_max_oos'] ) ) {
 			$max_oos = $options['ipq_site_max_oos'];
 		} else {
 			$max_oos = '';
 		}
-		
+
 		if( isset( $options['ipq_site_step'] ) ) {
 			$step = $options['ipq_site_step'];
 		} else {
-			$step = '';			
+			$step = '';
 		}
 
 		switch ( $type ) {
 			case 'all':
-				return array( 
-					'min_value' => $min, 
+				return array(
+					'min_value' => $min,
 					'max_value' => $max,
 					'min_oos' 	=> $min_oos,
 					'max_oos' 	=> $max_oos,
 					'step' 		=> $step
 				);
 				break;
-				
+
 			case 'min':
-				return array( 'min' => $min );					
+				return array( 'min' => $min );
 				break;
-			
-			case 'max': 
-				return array( 'max' => $max );		
+
+			case 'max':
+				return array( 'max' => $max );
 				break;
-			
-			case 'min_oos': 
-				return array( 'min_oos' => $min_oos );		
+
+			case 'min_oos':
+				return array( 'min_oos' => $min_oos );
 				break;
-				
-			case 'max_oos': 
-				return array( 'max_oos' => $max_oos );		
+
+			case 'max_oos':
+				return array( 'max_oos' => $max_oos );
 				break;
-				
+
 			case 'step':
-				return array( 'step' => $step );				
+				return array( 'step' => $step );
 				break;
-				
+
 			case 'priority':
 				return null;
 				break;
-		
+
 		}
-		
+
 	// Return Values from the Rule based on $type requested
 	} else {
-	
+
 		switch ( $type ) {
 			case 'all':
-				return array( 
+				return array(
 						'min_value' => get_post_meta( $rule->ID, '_min', true ),
 						'max_value' => get_post_meta( $rule->ID, '_max', true ),
 						'min_oos'	=> get_post_meta( $rule->ID, '_min_oos', true ),
@@ -314,35 +314,35 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 						'roles' 	=> get_post_meta( $rule->ID, '_roles', true )
 					);
 				break;
-				
+
 			case 'min':
 				return get_post_meta( $rule->ID, '_min', true );
 				break;
-			
-			case 'max': 
+
+			case 'max':
 				return get_post_meta( $rule->ID, '_max', true );
 				break;
-			
-			case 'min_oos': 
+
+			case 'min_oos':
 				return get_post_meta( $rule->ID, '_min_oos', true );
 				break;
-				
-			case 'max_oos': 
+
+			case 'max_oos':
 				return get_post_meta( $rule->ID, '_max_oos', true );
 				break;
-				
+
 			case 'step':
 				return get_post_meta( $rule->ID, '_step', true );
 				break;
-			
+
 			case 'role':
 				return get_post_meta( $rule->ID, '_roles', true );
 				break;
-				
+
 			case 'priority':
 				return get_post_meta( $rule->ID, '_priority', true );
 				break;
-		}				
+		}
 	}
 }
 
@@ -350,22 +350,22 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 *	Validate inputs as numbers and set them to null if 0
 */
 function wcqu_validate_number( $number ) {
-	
+
 	$number = stripslashes( $number );
 //	$number = intval( $number );
-	
+
 	if ( $number == 0 ) {
 		return null;
 	} elseif ( $number < 0 ) {
 		return null;
-	} 
-	
+	}
+
 	return $number;
 }
 
 /**
  * Provides a fmod function that actually works as intended.
- * 
+ *
  * @param float $x The dividend
  * @param float $y The divisor
  *
@@ -412,10 +412,9 @@ if ( ! function_exists( 'wpbo_get_value_from_rule' ) ) {
 	}
 }
 
-
 /**
- * This is ugly, but we need to pretend that the pre-forked version of this plugin is active since Thumbnail Quantities 
- * does a check whether it active. It'd be nice if they just made it a filter instead. Also TQ has some incorrect 
+ * This is ugly, but we need to pretend that the pre-forked version of this plugin is active since Thumbnail Quantities
+ * does a check whether it active. It'd be nice if they just made it a filter instead. Also TQ has some incorrect
  * javascript rounding on decimal values, so we may just have to fork it at some point as well.
  */
 add_filter( 'active_plugins', function($plugins){

--- a/quantites-and-units.php
+++ b/quantites-and-units.php
@@ -6,22 +6,22 @@ Description: Easily require your customers to buy a minimum / maximum / incremen
 Version: 1.0.13
 Author: Nicholas Verwymeren
 Author URI: https://www.nickv.codes
-*/ 
+*/
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 if ( ! class_exists( 'WC_Quantities_and_Units' ) ) :
 
 class WC_Quantities_and_Units {
-	
+
 	public $wc_version;
-	
+
 	/**
 	 * @var WooCommerce Supplier instance
 	 * @since 2.1
 	 */
 	protected static $_instance = null;
-	
+
 	/**
 	 * Main Incremental Product Quantities Instance
 	 *
@@ -33,14 +33,14 @@ class WC_Quantities_and_Units {
 		}
 		return self::$_instance;
 	}
-	
+
 	public function __construct() {
-		
+
 		// Activation / Deactivation Hooks
 		register_activation_hook( __FILE__, array( $this, 'activation_hook' ) );
 		register_activation_hook( __FILE__, array( $this, 'update_rules_with_roles' ) );
 		register_deactivation_hook( __FILE__, array( $this, 'deactivation_hook' ) );
-		
+
 		// Include Required Files
 		require_once( 'includes/wcqu-functions.php' );
 		require_once( 'includes/class-wcqu-filters.php' );
@@ -51,15 +51,15 @@ class WC_Quantities_and_Units {
 		require_once( 'includes/class-wcqu-advanced-rules.php' );
 		require_once( 'includes/class-wcqu-units-box.php' );
 		require_once( 'includes/class-wcqu-product-unit.php' );
-		
-		// Add Scripts and styles		
+
+		// Add Scripts and styles
 		add_action( 'wp_enqueue_scripts', array( $this, 'input_value_validation' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'admin_init', array( $this, 'quantity_styles' ) );
-		
-		// Set WC Version Number 
+
+		// Set WC Version Number
 		add_action( 'init', array( $this, 'get_wc_version' ) );
-		
+
 		// Control Admin Notices
 //		add_action( 'admin_notices', array( $this, 'thumbnail_plugin_notice' ) );
 		add_action( 'admin_init', array( $this, 'thumbnail_plugin_notice_ignore' ) );
@@ -72,17 +72,17 @@ class WC_Quantities_and_Units {
 		remove_filter( 'woocommerce_stock_amount', 'intval' );
 
 		// allow decimal floats
-		add_filter( 'woocommerce_stock_amount', 'floatval' );	
+		add_filter( 'woocommerce_stock_amount', 'floatval' );
 	}
 
 	/*
 	*	Adds default option values
-	*/	
+	*/
 	public function activation_hook() {
 
 		$options = get_option( 'ipq_options' );
-		
-		$defaults = array (		
+
+		$defaults = array (
 			'ipq_site_rule_active'	=> '',
 			'ipq_site_min'			=> '',
 			'ipq_site_max' 			=> '',
@@ -90,18 +90,18 @@ class WC_Quantities_and_Units {
 			'ipq_site_rule_active'	=> '',
 			'ipq_show_qty_note' 	=> '',
 			'ipq_qty_text'			=> 'Minimum Qty: %MIN%',
-			'ipq_show_qty_note_pos' => 'below',	
+			'ipq_show_qty_note_pos' => 'below',
 			'ipq_qty_class'			=> ''
 		);
 
 		// If no options set the defaults
 		if ( $options == false ) {
 			add_option( 'ipq_options', $defaults, '', false );
-		
+
 		// Otherwise check that all option are set
 		} else {
 			$needs_update = FALSE;
-			
+
 			// Check and assign each unset value
 			foreach ( $defaults as $key => $value ) {
 				if ( !isset( $options[$key] ) ) {
@@ -109,7 +109,7 @@ class WC_Quantities_and_Units {
 					$needs_update = TRUE;
 				}
 			}
-			
+
 			// If values are missing update the options
 			if ( $needs_update === TRUE ) {
 				update_option( 'ipq_options', $options );
@@ -121,48 +121,48 @@ class WC_Quantities_and_Units {
 	*	'Checks' all user roles for pre-2.1 rules
 	*
 	*	@status To be depricated in version 2.3
-	*/	
+	*/
 	public function update_rules_with_roles() {
-		
+
 		// Construct default roles list to apply
 		global $wp_roles;
 		$roles = $wp_roles->get_names();
 		$applied_roles = array();
 		foreach ( $roles as $slug => $name ) {
 			array_push( $applied_roles, $slug );
-		} 
-		
+		}
+
 		$args = array (
 			'posts_per_page'   	=> -1,
 			'post_type'        	=> 'quantity-rule',
 			'post_status'      	=> 'publish',
 		);
-		
+
 		$rules = get_posts( $args );
-		
+
 		// Loop through rules
 		foreach ( $rules as $rule ) {
-			// If their rule value is false, apply all roles 
+			// If their rule value is false, apply all roles
 			$roles = get_post_meta( $rule->ID, '_roles', true );
-			
+
 			if ( $roles == false ) {
 				update_post_meta( $rule->ID, '_roles', $applied_roles, false );
 			}
 		}
 	}
-	
+
 	/*
 	*	Remove thumbnail plugin notice meta value
-	*/	
+	*/
 	public function deactivation_hook() {
-	
+
 		$args = array(
 			'meta_key'     => 'wpbo_thumbnail_input_notice',
 			'meta_value'   => 'true',
 		 );
-	
+
 		$admins = get_users( $args );
-		
+
 		foreach ( $admins as $admin ) {
 			delete_user_meta( $admin->ID, 'wpbo_thumbnail_input_notice' );
 		}
@@ -176,130 +176,130 @@ class WC_Quantities_and_Units {
 	}
 
 	/*
-	*	Include JS to round any value that isn't a multiple of the 
+	*	Include JS to round any value that isn't a multiple of the
 	*	step up.
-	*/	
+	*/
 	public function input_value_validation() {
-	
+
 		global $post, $woocommerce;
-	
+
 		// Only display script if we are on a single product or cart page
 		if ( is_object( $post ) and $post->post_type == 'product' or is_cart() ) {
-			
-			wp_enqueue_script( 
-				'ipq_validation', 
+
+			wp_enqueue_script(
+				'ipq_validation',
 				plugins_url( '/assets/js/ipq_input_value_validation.js', __FILE__ ),
 				array( 'jquery' )
 			);
 
 			// Only localize parameters for variable products
 			if ( ! is_cart() ) {
-				
+
 				// Get the product
-				$pro = get_product( $post );
-				
+				$pro = wc_get_product( $post );
+
 				// Check if variable
-				if ( $pro->product_type == 'variable' ) {
+				if ( $pro->get_type() == 'variable' ) {
 
 					// See what rules are being applied
 					$rule_result = wcqu_get_applied_rule( $pro );
-				
+
 					// If the rule result is inactive, we're done
 					if ( $rule_result == 'inactive' or $rule_result == null ) {
 						return;
-					
+
 					// Get values for Override, Sitewide and Rule Controlled Products
 					} else {
 						$values = wcqu_get_value_from_rule( 'all', $pro, $rule_result );
 					}
-					
-					// Check if the product is out of stock 
+
+					// Check if the product is out of stock
 					$stock = $pro->get_stock_quantity();
-			
+
 					// Check if the product is under stock management and out of stock
 					if ( strlen( $stock ) != 0 and $stock <= 0 ) {
-						
+
 						if ( $values['min_oos'] != '' ) {
 							$values['min_value'] = $values['min_oos'];
 						}
-						
+
 						if ( $values['max_oos'] != '' ) {
 							$values['max_value'] = $values['max_oos'];
 						}
-						
+
 					}
-						
+
 					// Output admin-ajax.php URL with sma eprotocol as current page
 					$params = array (
 						'min' => $values['min_value'],
 						'max' => $values['max_value'],
 						'step' => $values['step']
-					);	
-					
+					);
+
 					wp_localize_script( 'ipq_validation', 'ipq_validation', $params );
 				}
-			}		
-		}		
+			}
+		}
 	}
-	
+
 	/*
 	*	Include Styles
-	*/	
+	*/
 	public function quantity_styles() {
-	
+
 		if ( is_admin() ) {
-		
-			wp_enqueue_style( 
-				'wcqu_admin_quantity_styles', 
+
+			wp_enqueue_style(
+				'wcqu_admin_quantity_styles',
 				plugins_url( '/assets/css/admin-styles.css', __FILE__ )
 			);
-					
-			wp_enqueue_script( 
-				'wcqu_admin_script', 
+
+			wp_enqueue_script(
+				'wcqu_admin_script',
 				plugins_url( '/assets/js/ipq_admin_script.js', __FILE__ ),
 				array( 'jquery' )
 			);
 		}
 	}
-	
+
 	/*
-	*	Set what version of WooCommerce the user has installed 
-	*/	
+	*	Set what version of WooCommerce the user has installed
+	*/
 	public function get_wc_version() {
-			
+
 		if ( ! function_exists( 'get_plugins' ) )
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		
+
 		$plugin_folder = get_plugins( '/' . 'woocommerce' );
 		$plugin_file = 'woocommerce.php';
-		
+
 		if ( isset( $plugin_folder[$plugin_file]['Version'] ) ) {
 			$this->wc_version = $plugin_folder[$plugin_file]['Version'];
 		} else {
 			$this->wc_version = NULL;
 		}
 	}
-	
+
 	/*
 	* 	General Admin Notice to Encourage users to download thumbnail input as well
-	*/	
+	*/
 	public function thumbnail_plugin_notice() {
 
 		global $current_user;
-		$user_id = $current_user->ID; 
+		$user_id = $current_user->ID;
 
-		// Check if Thumbnail Plugin is activated	
+		// Check if Thumbnail Plugin is activated
 		if ( !in_array( 'woocommerce-thumbnail-input-quantities/woocommerce-thumbnail-input-quantity.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
-		
+
 			// Check if User has Dismissed this message already
 			if ( ! get_user_meta( $user_id, 'wpbo_thumbnail_input_notice' ) ) {
-				
+
 				echo '<div class="updated">
 			       <p><strong>Notice:</strong> It is highly recommended you install and activate the <a href="http://wordpress.org/plugins/woocommerce-thumbnail-input-quantities/" target="_blank">WooCommerce Thumbnail Input Quantites</a> plugin to display input boxes on products thumbnails. <a href="';
-			       
-			       // Echo the current url 
+
+			       // Echo the current url
 			       echo site_url() . $_SERVER['REQUEST_URI'];
-			       
+
 			       // Echo notice variable as nth get variable with &
 			       if ( strpos( $_SERVER['REQUEST_URI'] , '?' ) !== false ) {
 				       echo '&wpbo_thumbnail_plugin_dismiss=0';
@@ -307,19 +307,19 @@ class WC_Quantities_and_Units {
 			       } else {
 				       echo '?wpbo_thumbnail_plugin_dismiss=0';
 			       }
-			       
+
 			    echo '">Dismiss Notice</a></p></div>';
 			}
-		} 
+		}
 	}
-	
+
 	/*
 	*	Make Admin Notice Dismissable
-	*/	
+	*/
 	public function thumbnail_plugin_notice_ignore() {
 		global $current_user;
 		$user_id = $current_user->ID;
-		
+
 		if ( isset($_GET['wpbo_thumbnail_plugin_dismiss']) && '0' == $_GET['wpbo_thumbnail_plugin_dismiss'] ) {
 			add_user_meta($user_id, 'wpbo_thumbnail_input_notice', 'true', true);
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -2,24 +2,24 @@
 Contributors: greatwitenorth
 Tags: woocommerce, product quantities, product minimum values, product maximum values, product step values, incremental product quantities, min, max, decimal
 Donate link: https://www.nickv.codes/donate
-Requires at least: 3.5
-Tested up to: 4.3
-Stable tag: 1.0.13
+Requires at least: 5.8
+Tested up to: 5.8
+Stable tag: 2.0.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Easily require your customers to buy a minimum / maximum / incremental amount of products. Supports decimal quantities.
 
 == Description ==
-NOTE: This plugin has been forked from the "Advanced Product Quantities" plugin. It adds decimal quantities support and 
-units to products. Please don't attempt to run both plugins simultaneously. It not needed and the universe will 
+NOTE: This plugin has been forked from the "Advanced Product Quantities" plugin. It adds decimal quantities support and
+units to products. Please don't attempt to run both plugins simultaneously. It not needed and the universe will
 probably implode.
 
-With Quantities and Units for WooCommerce you can easily create rules that restrict the amount of products a user can 
-buy at once. Set Minimum, Maximum and Step values for any product type and must be valid before a customer can proceed 
+With Quantities and Units for WooCommerce you can easily create rules that restrict the amount of products a user can
+buy at once. Set Minimum, Maximum and Step values for any product type and must be valid before a customer can proceed
 to checkout. Quantities and Units also bring decimal quantity support to WooCommerce.
 
-This plugin works great with [Rapid Order](http://rapidorderplugin.com/), a fast ordering system for WooCommerce. 
+This plugin works great with [Rapid Order](http://rapidorderplugin.com/), a fast ordering system for WooCommerce.
 
 New Features
 
@@ -47,7 +47,7 @@ Features:
 * Now fully supports ALL PRODUCT TYPES, simple, variable, grouped and affiliate
 * Create Site Wide rules that apply to every product unless overwritten on a per-product basis
 * Create rules by Product Tags (opposed to just categories)
-* Woocommerce +2.0 compatible 
+* Woocommerce +2.0 compatible
 
 == Installation ==
 
@@ -74,7 +74,7 @@ Manual Installation
 * Fixed input issue introduced in 10.0.12 release
 
 = 1.0.12 =
-* Fixed an issue where sometimes the correct value would not display when using decimal quantities. 
+* Fixed an issue where sometimes the correct value would not display when using decimal quantities.
 
 = 1.0.11 =
 * Fixed issue with max value causing amount not to increment correctly in some circumstances.
@@ -119,7 +119,7 @@ Manual Installation
 == Screenshots ==
 
 1. Single product page, page loads with it's minimum quantity and notifies the user below.
-1. Create rule page. 
+1. Create rule page.
 1. Single product 'Product Quantity Rules' meta box. Deactivate or override rules. Even set out of stock min/max values.
 1. Single product 'Product Quantity Rules' meta box. Display of values by user role.
 1. 'Advanced Rules' page, set sitewide rules and configure quantity notifications (screenshot 1)


### PR DESCRIPTION
BREAKING CHANGE: The plugin now use WooCommerce CRUD (e.g. `$product->get_id()` instead of
`$product->id`) and therefore drops support for older woocommerce versions. Furthermore some
deprecated wordpress functions are now updated to the current major v5